### PR TITLE
Update Tracy + fix GPU context name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ rustc_version = "0.4"
 
 [dependencies]
 ctor = { version = "0.2", optional = true }
-sys = { package = "tracy-client-sys", version = "0.22.2", default-features = false }
+sys = { package = "tracy-client-sys", version = "0.23.0", default-features = false }
 
 bevy_ecs = { version = "0.13", optional = true }
 futures-lite = { version = "2.0", optional = true }

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -258,7 +258,7 @@ impl ProfileContext {
 
 		#[cfg(feature = "enable")]
 		unsafe {
-			sys::___tracy_emit_gpu_context_name(sys::___tracy_gpu_context_name_data {
+			sys::___tracy_emit_gpu_context_name_serial(sys::___tracy_gpu_context_name_data {
 				context: this.context,
 				name: name.as_ptr() as _,
 				len: name.len() as _,

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -350,6 +350,7 @@ impl ProfileContext {
 						function.len(),
 						label.as_ptr() as _,
 						label.len(),
+						0,
 					),
 					None => sys::___tracy_alloc_srcloc(
 						line,
@@ -357,6 +358,7 @@ impl ProfileContext {
 						file.len(),
 						function.as_ptr() as _,
 						function.len(),
+						0,
 					),
 				};
 


### PR DESCRIPTION
Hi!

I've been trying to use `tracy_full` crate for `wgpu` GPU profiling on macOS. Upon connecting, the Tracy Profiler app frequently ran into an assert and crashed. Noticed that while GPU zone begin/end functions use the serial API from Tracy, setting the GPU context name at initialization doesn't. Fixed by switching to the serial variant. As explained in Section 3.13.7 (GPU zones) of [Tracy v0.11 docs](https://github.com/wolfpld/tracy/releases/download/v0.11.0/tracy.pdf), serial function are expected to be used for multi-threaded graphics APIs like Metal:
> Moreover, there are two sets of functions described below. The standard set sends data asynchronously, while the `_serial` one ensures proper ordering of all events, regardless of the originating thread. Generally speaking, you should be using the asynchronous functions only in the case of strictly single-threaded APIs, like OpenGL.

Also updated `tracy-client-sys` dependency, to be compatible with Tracy v0.11. [Release notes](https://github.com/wolfpld/tracy/releases/tag/v0.11.0) provided guidance on how to fix a single breaking change encountered:
> `__tracy_alloc_srcloc` and `__tracy_alloc_srcloc_name` break the existing API. This can be easily fixed by setting the last parameter to zero.