### PR TITLE
Update wgpu + fix CPU blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bevy_ecs = { version = "0.13", optional = true }
 futures-lite = { version = "2.0", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
-wgpu = { version = "0.20", optional = true, default-features = false }
+wgpu = { version = "22.1", optional = true, default-features = false }
 
 [target.'cfg(not(unstable))'.dependencies]
 once_cell = "1.10.0"

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -214,7 +214,7 @@ impl ProfileContext {
 				});
 				encoder.write_timestamp(&pool.query, 0);
 				encoder.resolve_query_set(&pool.query, 0..1, &pool.resolve, 0);
-				encoder.copy_buffer_to_buffer(&pool.resolve, 0, &pool.readback, 0, pool.resolve.size());
+				encoder.copy_buffer_to_buffer(&pool.resolve, 0, &pool.readback, 0, 8);
 				queue.submit([encoder.finish()]);
 				let slice = pool.readback.slice(0..8);
 				slice.map_async(MapMode::Read, |_| {});
@@ -311,7 +311,7 @@ impl ProfileContext {
 			});
 			for pool in &mut frame.pools {
 				encoder.resolve_query_set(&pool.query, 0..(pool.used_queries as u32), &pool.resolve, 0);
-				encoder.copy_buffer_to_buffer(&pool.resolve, 0, &pool.readback, 0, pool.resolve.size());
+				encoder.copy_buffer_to_buffer(&pool.resolve, 0, &pool.readback, 0, pool.used_queries as u64 * 8);
 			}
 			queue.submit([encoder.finish()]);
 


### PR DESCRIPTION
Hi!

This PR fixes a CPU-GPU synchronization point in `ProfileContext::end_frame()`, where `device.poll(Maintain::Wait)` blocked the CPU. The CPU waited for the GPU to finish executing all submitted commands on the queue, stopping overlapping CPU-GPU work, and most importantly affecting measurements we can inspect in Tracy.

Instead, the function can wait for a specific, older submission on the queue. Trailing by `buffered_frames-1` amount of frames, the function reads back older timestamp query results while the GPU continues to process more recent commands, keeping parallelism active. The function now sends `map_async()` commands right after `resolve_query_set()` commands to ensure that the buffer mapping request - assuming `buffered_frames` is set correctly - completes by the time the CPU wants to read query results back by calling `get_mapped_range()`.

Also updated `wgpu` dependency. Buffer usages `MAP_READ` and `QUERY_RESOLVE` are no longer permitted at the same time on a buffer. `QueryPool::readback` therefore now needs to be two buffers: one for resolving queries, and another for reading on the CPU. Finally, [lifetime bounds on `wgpu::RenderPass`](https://github.com/gfx-rs/wgpu/blob/trunk/CHANGELOG.md#lifetime-bounds-on-wgpurenderpass--wgpucomputepass) saw a small change.
